### PR TITLE
Correct the manual install command line

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ script:
 - examples/dashboard.py XXX
 - examples/create_dashboard.py XXX
 - examples/delete_dashboard.py XXX
-- examples/get_data_advanced.py XXX ip-10-0-1-213.ec2.internal
+- examples/get_data_advanced.py XXX ip-10-0-1-110.ec2.internal
 - examples/get_data_datasource.py XXX
 - examples/get_data_simple.py XXX
 - examples/list_alerts.py XXX
@@ -28,7 +28,7 @@ script:
 - examples/print_explore_grouping.py XXX
 - examples/print_user_info.py XXX
 - examples/list_sysdig_captures.py XXX
-- examples/create_sysdig_capture.py XXX ip-10-0-1-213.ec2.internal apicapture 10
+- examples/create_sysdig_capture.py XXX ip-10-0-1-110.ec2.internal apicapture 10
 - examples/notification_channels.py XXX
 - examples/user_team_mgmt.py XXX example-team example-user@example-domain.com
 - echo "Testing pip version"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ Installation
 
 #### Manual
     git clone https://github.com/draios/python-sdc-client.git
-    pip install
+    cd python-sdc-client
+    python setup.py install
 
 Quick start
 -----------


### PR DESCRIPTION
@jsrodman pointed out that the manual command line in the README didn't have the intended effect. I've seen the `setup.py` approach as a typical approach for installing with a local checkout. @jsrodman pointed out that `pip -e` is another option, but they both seem to land in the same place (particularly if they're using virtualenv as we suggest). @davideschiera, any opinions? If you're ok with what's here, feel free to merge.
