### PR TITLE
Address failing test for resolve_alert_notifications

### DIFF
--- a/examples/resolve_alert_notifications.py
+++ b/examples/resolve_alert_notifications.py
@@ -9,6 +9,16 @@ import time
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.realpath(sys.argv[0])), '..'))
 from sdcclient import SdcClient
 
+import logging
+import httplib
+httplib.HTTPConnection.debuglevel = 1
+
+logging.basicConfig() # you need to initialize logging, otherwise you will not see anything from requests
+logging.getLogger().setLevel(logging.DEBUG)
+requests_log = logging.getLogger("requests.packages.urllib3")
+requests_log.setLevel(logging.DEBUG)
+requests_log.propagate = True
+
 #
 # Parse arguments
 #

--- a/examples/resolve_alert_notifications.py
+++ b/examples/resolve_alert_notifications.py
@@ -52,6 +52,7 @@ notifications = res[1]['notifications']
 
 print "Resolving " + str(len(notifications)) + " notifications"
 for notification in notifications:
+    notification.pop('nonNullFilter', None)
     res = sdclient.update_notification_resolution(notification, True)
     if not res[0]:
         print res[1]

--- a/sdcclient/_client.py
+++ b/sdcclient/_client.py
@@ -166,6 +166,8 @@ class SdcClient:
         notification['resolved'] = resolved
         data = {'notification': notification}
 
+        print 'Notification to be resolved:'
+        print json.dumps(data, sort_keys=True, indent=4)
         res = requests.put(self.url + '/api/notifications/' + str(notification['id']), headers=self.hdrs, data=json.dumps(data))
         if not self.__checkResponse(res):
             return [False, self.lasterr]


### PR DESCRIPTION
NOT FOR MERGE. I'm just using the diffs to illustrate the problem, which I imagine should result in opening of an issue (backend?)

When working on the Python client library lately, I noticed the example `resolve_alert_notifications.py` from the automated tests kept failing. By comparing what the Python was `PUT`-ing with the equivalent working operation from a browser, I determined that what was causing the failure was that the Python included this line in the JSON:

```
       "nonNullFilter": "host.hostName = 'ubuntu16'",
```

That is, much of how the Python client uses the REST API relies on the ability to `GET` some object, make some very minor change (in this case, setting `resolved` to `true`) and then `PUT`-ing the object back at the relevant endpoint to complete an update. In this PR I was able to force the example to start working again by manually deleting the `nonNullFilter` key before `PUT`-ing it back, but I doubt this is what we want. As far as I know this example used to work, so I'm not sure what changed, and if the right fix is for the `GET` to not return this key or for the endpoint receiving the `PUT` to silently accept it. I can open a separate issue for whatever is the appropriate course of action.