### PR TITLE
Add support for getting IDs of OpsGenie Notification Channels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ script:
 - examples/dashboard.py XXX
 - examples/create_dashboard.py XXX
 - examples/delete_dashboard.py XXX
-- examples/get_data_advanced.py XXX ip-10-0-1-110.ec2.internal
+- examples/get_data_advanced.py XXX ip-10-0-1-140.ec2.internal
 - examples/get_data_datasource.py XXX
 - examples/get_data_simple.py XXX
 - examples/list_alerts.py XXX
@@ -28,7 +28,7 @@ script:
 - examples/print_explore_grouping.py XXX
 - examples/print_user_info.py XXX
 - examples/list_sysdig_captures.py XXX
-- examples/create_sysdig_capture.py XXX ip-10-0-1-110.ec2.internal apicapture 10
+- examples/create_sysdig_capture.py XXX ip-10-0-1-140.ec2.internal apicapture 10
 - examples/notification_channels.py XXX
 - examples/user_team_mgmt.py XXX example-team example-user@example-domain.com
 - echo "Testing pip version"

--- a/sdcclient/_client.py
+++ b/sdcclient/_client.py
@@ -213,6 +213,11 @@ class SdcClient:
                             if 'channel' in opt and opt['channel'] == c['channel']:
                                 found = True
                                 ids.append(ch['id'])
+                        elif c['type'] == 'OPSGENIE':
+                            if 'name' in c:
+                                if c['name'] == ch['name']:
+                                    found = True
+                                    ids.append(ch['id'])
                 if not found:
                     return [False, "Channel not found: " + str(c)]
 


### PR DESCRIPTION
Issue https://github.com/draios/python-sdc-client/issues/17 pointed out that `get_notification_ids()` was not prepared to find OpsGenie Notification Channels. This PR adds support for that. Tested it out by using `examples/create_alert.py` with `notify_channels = [ {'type': 'OPSGENIE', 'name': 'Cloud Platform OpsGenie'} ]` and it now found & created the Alert successfully with my OpsGenie channel.

![image](https://cloud.githubusercontent.com/assets/5934157/23675761/42852700-032f-11e7-9df8-539c4c7105c8.png)

cc: @adityakinifr @davideschiera 