### PR TITLE
Add support for Webhook Notification Channels when creating Alerts

### DIFF
--- a/examples/create_alert.py
+++ b/examples/create_alert.py
@@ -30,7 +30,7 @@ sdclient = SdcClient(sdc_token)
 # Find notification channels (you need IDs to create an alert).
 #
 notify_channels = [ {'type': 'SLACK', 'channel': 'sysdig-demo2-alerts'},
-                    {'type': 'EMAIL', 'emailRecipients': ['gianluca@sysdig.com']},
+                    {'type': 'EMAIL', 'emailRecipients': ['demo-kube@draios.com', 'test@sysdig.com']},
                     {'type': 'SNS', 'snsTopicARNs': ['arn:aws:sns:us-east-1:273107874544:alarms-stg']}
                     ]
 

--- a/sdcclient/_client.py
+++ b/sdcclient/_client.py
@@ -228,6 +228,11 @@ class SdcClient:
                                 if c['name'] == ch['name']:
                                     found = True
                                     ids.append(ch['id'])
+                        elif c['type'] == 'WEBHOOK':
+                            if 'name' in c:
+                                if c['name'] == ch['name']:
+                                    found = True
+                                    ids.append(ch['id'])
                 if not found:
                     return [False, "Channel not found: " + str(c)]
 


### PR DESCRIPTION
Added support for Webhook Notification Channels, as alerted in issue https://github.com/draios/python-sdc-client/issues/22.

Also noticed one of the automated tests was failing because it was pointing at an Email Notificaiton Channel with a personal email address that no longer existed in the test demo-kube environment. I fixed this by pointing to a channel with test addresses that still exists.
