### PR TITLE
create_alert with duplicate descriptions should be permitted

### DIFF
--- a/sdcclient/_client.py
+++ b/sdcclient/_client.py
@@ -271,14 +271,6 @@ class SdcClient:
         j = res.json()
 
         #
-        # If this alert already exists, don't create it again
-        #
-        for db in j['alerts']:
-            if 'description' in db:
-                if db['description'] == description:
-                    return [False, 'alert ' + name + ' already exists']
-
-        #
         # Populate the alert information
         #
         alert_json = {


### PR DESCRIPTION
https://github.com/draios/python-sdc-client/issues/24 alerted us to the fact that `create_alert()` was failing if two Alerts were created with the same description. The UI allows this and the API works fine if we just remove the offending code, so I've done that here. I've run it by @ldegio on Slack who wrote the original code and he's :+1: on the change, so I'm gonna go ahead and merge it.