### PR TITLE
Add update_alert()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
 script:
 - echo "Testing source version"
 - examples/create_alert.py XXX
+- examples/update_alert.py XXX
 - examples/delete_alert.py XXX
 - examples/dashboard.py XXX
 - examples/create_dashboard.py XXX

--- a/examples/update_alert.py
+++ b/examples/update_alert.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+#
+# This script shows how to use the update_alert() call to modify the
+# details of an existing alert.
+#
+#
+
+import os
+import sys
+import json
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.realpath(sys.argv[0])), '..'))
+from sdcclient import SdcClient
+
+#
+# Parse arguments
+#
+if len(sys.argv) != 2:
+    print 'usage: %s <sysdig-token>' % sys.argv[0]
+    print 'You can find your token at https://app.sysdigcloud.com/#/settings/user'
+    sys.exit(1)
+
+sdc_token = sys.argv[1]
+
+#
+# Instantiate the SDC client
+#
+sdclient = SdcClient(sdc_token)
+
+res = sdclient.get_alerts()
+if not res[0]:
+    print res[1]
+    sys.exit(1)
+
+alert_found = False
+for alert in res[1]['alerts']:
+    if alert['name'] == "tomcat cpu > 80% on any host":
+        alert_found = True
+        print 'Updating alert. Configuration before changing timespan, description, and notification channels:'
+        print json.dumps(alert, sort_keys=True, indent=4)
+        alert['notificationChannelIds'] = alert['notificationChannelIds'][0:-1]
+        alert['description'] = 'this alert has been updated via update_alert in the python Sysdig Monitor library'
+        alert['timespan'] = 120 * 1000000    # 2 minutes
+        res_update = sdclient.update_alert(alert)
+
+        # Validate and print the results
+        print '\nAlert after modification:'
+        print json.dumps(res_update[1], sort_keys=True, indent=4)
+        if not res_update[0]:
+            sys.exit(1)
+
+if not alert_found:
+    print 'Alert to be updated not found'
+    sys.exit(1)

--- a/examples/update_alert.py
+++ b/examples/update_alert.py
@@ -37,16 +37,21 @@ for alert in res[1]['alerts']:
         alert_found = True
         print 'Updating alert. Configuration before changing timespan, description, and notification channels:'
         print json.dumps(alert, sort_keys=True, indent=4)
-        alert['notificationChannelIds'] = alert['notificationChannelIds'][0:-1]
-        alert['description'] = 'this alert has been updated via update_alert in the python Sysdig Monitor library'
-        alert['timespan'] = 120 * 1000000    # 2 minutes
+        if 'notificationChannelIds' in alert:
+            alert['notificationChannelIds'] = alert['notificationChannelIds'][0:-1]
+        update_txt = ' (changed by update_alert)'
+        if alert['description'][-len(update_txt):] != update_txt:
+            alert['description'] = alert['description'] + update_txt
+        alert['timespan'] = alert['timespan'] * 2   # Note: Expressed in seconds * 1000000
         res_update = sdclient.update_alert(alert)
+
+        if not res_update[0]:
+            print res_update[1]
+            sys.exit(1)
 
         # Validate and print the results
         print '\nAlert after modification:'
         print json.dumps(res_update[1], sort_keys=True, indent=4)
-        if not res_update[0]:
-            sys.exit(1)
 
 if not alert_found:
     print 'Alert to be updated not found'

--- a/sdcclient/_client.py
+++ b/sdcclient/_client.py
@@ -304,6 +304,28 @@ class SdcClient:
             return [False, self.lasterr]
         return [True, res.json()]
 
+    def update_alert(self, alert):
+        '''**Description**
+            Update a modified threshold-based alert.
+
+        **Arguments**
+            - **alert**: one alert object from a list returned by :func:`~SdcClient.get_alerts`.
+
+        **Success Return Value**
+            The updated alert.
+
+        **Example**
+            `examples/update_alert.py <https://github.com/draios/python-sdc-client/blob/master/examples/update_alert.py>`_
+        '''
+        if 'id' not in alert:
+            return [False, "Invalid alert format"]
+
+        res = requests.put(self.url + '/api/alerts/' + str(alert['id']), headers=self.hdrs, data=json.dumps({ "alert": alert}), verify=self.ssl_verify)
+        if not self.__checkResponse(res):
+            return [False, self.lasterr]
+
+        return [True, res.json()]
+
     def delete_alert(self, alert):
         '''**Description**
             Deletes an alert.

--- a/sdcclient/_client.py
+++ b/sdcclient/_client.py
@@ -309,7 +309,7 @@ class SdcClient:
             Update a modified threshold-based alert.
 
         **Arguments**
-            - **alert**: one alert object from a list returned by :func:`~SdcClient.get_alerts`.
+            - **alert**: one modified alert object of the same format as those in the list returned by :func:`~SdcClient.get_alerts`.
 
         **Success Return Value**
             The updated alert.


### PR DESCRIPTION
https://github.com/draios/python-sdc-client/issues/26 called out the need for an `update_alert()` function. This PR adds the new function and an example to be run as an automated test. The automated test has passed in Travis on the branch, and includes the three types of alert modifications suggested by the end user.