### PR TITLE
Alerts create/backup/restore with JSON file

### DIFF
--- a/examples/list_alerts.py
+++ b/examples/list_alerts.py
@@ -1,20 +1,25 @@
 #!/usr/bin/env python
 #
 # Print 'enabled' flag and name for all of the alerts created by the user
+# Optionally dump the full Alerts list as a JSON object to a target file.
 #
 
 import os
 import sys
+import json
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.realpath(sys.argv[0])), '..'))
 from sdcclient import SdcClient
 
 #
 # Parse arguments
 #
-if len(sys.argv) != 2:
-    print 'usage: %s <sysdig-token>' % sys.argv[0]
+json_dumpfilename = None
+if len(sys.argv) < 2 or len(sys.argv) > 3:
+    print 'usage: %s <sysdig-token> [json-dumpfile]' % sys.argv[0]
     print 'You can find your token at https://app.sysdigcloud.com/#/settings/user'
     sys.exit(1)
+elif len(sys.argv) == 3:
+    json_dumpfilename = sys.argv[2]
 
 sdc_token = sys.argv[1]
 
@@ -39,3 +44,7 @@ else:
 
 for alert in data['alerts']:
     print 'enabled: %s, name: %s' % (str(alert['enabled']), alert['name'])
+
+if json_dumpfilename:
+    with open(json_dumpfilename, "w") as f:
+        json.dump(data, f, sort_keys=True, indent=4)

--- a/examples/restore_alerts.py
+++ b/examples/restore_alerts.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+#
+# Restore Alerts of the format in a JSON dumpfile from the list_alerts.py example.
+#
+
+import os
+import sys
+import json
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.realpath(sys.argv[0])), '..'))
+from sdcclient import SdcClient
+
+#
+# Parse arguments
+#
+if len(sys.argv) != 3:
+    print 'usage: %s <sysdig-token> <file-name>' % sys.argv[0]
+    print 'You can find your token at https://app.sysdigcloud.com/#/settings/user'
+    sys.exit(1)
+
+sdc_token = sys.argv[1]
+alerts_dump_file = sys.argv[2]
+
+#
+# Instantiate the SDC client
+#
+sdclient = SdcClient(sdc_token)
+
+with open(alerts_dump_file, 'r') as f:
+    j = json.load(f)
+    for a in j['alerts']:
+        res = sdclient.create_alert(alert_obj=a)
+        if not res[0]:
+            print res[1]
+            sys.exit(1)
+
+print 'All Alerts in ' + alerts_dump_file + ' created successfully.'

--- a/examples/restore_alerts.py
+++ b/examples/restore_alerts.py
@@ -28,6 +28,7 @@ sdclient = SdcClient(sdc_token)
 with open(alerts_dump_file, 'r') as f:
     j = json.load(f)
     for a in j['alerts']:
+        a['description'] += ' (created via restore_alerts.py)'
         res = sdclient.create_alert(alert_obj=a)
         if not res[0]:
             print res[1]

--- a/examples/restore_dashboards.py
+++ b/examples/restore_dashboards.py
@@ -28,16 +28,23 @@ sdclient = SdcClient(sdc_token)
 
 zipf = zipfile.ZipFile(dashboard_state_file, 'r')
 
+
+dashboard_conf_items = ['showAsType', 'filterRoot', 'linkMetrics',
+                        'singleTimeNavigation', 'gridConfiguration', 'responsive',
+                        'nodesNoiseFilter', 'compareWith', 'format', 'linksNoiseFilter',
+                        'filterProcesses', 'isLegendExpanded', 'inhertitTimeNavigation',
+                        'schema', 'sortAscending', 'mapDataLimit', 'metrics', 'filterExtNodes',
+                        'sorting', 'name', 'sourceExploreView', 'items', 'showAs', 'eventsFilter',
+                        'timeMode', 'isShared', 'sourceDrilldownView']
+
 for info in zipf.infolist():
     data = zipf.read(info.filename)
-    dboard = json.loads(data)
-    
-    dboard['timeMode'] = {'mode' : 1}
-    dboard['time'] = {'last' : 2 * 60 * 60 * 1000000, 'sampling' : 2 * 60 * 60 * 1000000}
-
-    # Single filter support for all restored dashboards
-    # TODO: add support to get filter from saved dashboard
-    dashboardFilter = "proc.name = cassandra"
-    res = sdclient.create_dashboard_from_template(dboard['name'] + '-restored', dboard, dashboardFilter)
+    j = json.loads(data)
+    k = {}
+    for item in j.keys():
+        if item in dashboard_conf_items:
+            k[item] = j[item]
+     
+    res = sdclient.create_dashboard_with_configuration(k)
     if res[0] == False:
         print "Dashboard creation failed for dashboard name %s with error %s" % (j['name'], res[1])

--- a/sdcclient/_client.py
+++ b/sdcclient/_client.py
@@ -256,7 +256,7 @@ class SdcClient:
             - **notify**: the type of notification you want this alert to generate. Options are *EMAIL*, *SNS*, *PAGER_DUTY*, *SYSDIG_DUMP*.
             - **enabled**: if True, the alert will be enabled when created.
             - **annotations**: an optional dictionary of custom properties that you can associate to this alert for automation or management reasons
-            - **alert_obj**: an optional fully-formed Alert object of the format returned in an "alerts" list by :func:`~SdcClient.get_alerts` This is an alternative to creating the Alert using the individiual parameters listed above.
+            - **alert_obj**: an optional fully-formed Alert object of the format returned in an "alerts" list by :func:`~SdcClient.get_alerts` This is an alternative to creating the Alert using the individual parameters listed above.
 
         **Success Return Value**
             A dictionary describing the just created alert, with the format described at `this link <https://app.sysdigcloud.com/apidocs/#!/Alerts/post_api_alerts>`__

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='sdcclient',
-      version='0.5.1',
+      version='0.5.2',
       description='Python client for Sysdig Cloud',
       url='http://github.com/draios/python-sdc-client',
       author='sysdig Inc.',


### PR DESCRIPTION
https://github.com/draios/python-sdc-client/issues/27 identified a desire to be able to create Alerts using full JSON objects in a file as opposed to the current `create_alert()` which requires specifying the separate Alert details in the call to the Python method. This PR tries to kill two birds with one stone by extending the `list_alerts.py` example to dump the full set of Alerts to a JSON file, and adds a new `restore_alerts.py` example that reads them back in from such a file. Now we have backup/restore examples, and at the same time someone could use the "restore" example to create wholly new Alerts as long as they follow the right JSON format.