### PR TITLE
Enhance "restore alerts" example to include updates (previously was only creates)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ script:
 - examples/print_explore_grouping.py XXX
 - examples/print_user_info.py XXX
 - examples/list_sysdig_captures.py XXX
-- examples/create_sysdig_capture.py XXX ip-10-0-1-140.ec2.internal apicapture 10
+- examples/create_sysdig_capture.py XXX ip-10-0-1-115.ec2.internal apicapture 10
 - examples/notification_channels.py XXX
 - examples/user_team_mgmt.py XXX example-team example-user@example-domain.com
 - echo "Testing pip version"

--- a/examples/restore_alerts.py
+++ b/examples/restore_alerts.py
@@ -25,13 +25,41 @@ alerts_dump_file = sys.argv[2]
 #
 sdclient = SdcClient(sdc_token)
 
+#
+# If the dump we're restoring from has an Alert with the same name
+# as one that's already configured, we'll update the existing Alert
+# so it will have the config from the dump. When we do this, however,
+# we need to give the ID and Version # of the existing Alert as a
+# basis. We save them off here so we can refer to them later.
+#
+existing_alerts = {}
+res = sdclient.get_alerts()
+if res[0]:
+    for alert in res[1]['alerts']:
+        existing_alerts[alert['name']] = { 'id': alert['id'], 'version': alert['version'] }
+else:
+    print res[1]
+    sys.exit(1)
+
+created_count = 0
+updated_count = 0
+
 with open(alerts_dump_file, 'r') as f:
     j = json.load(f)
     for a in j['alerts']:
-        a['description'] += ' (created via restore_alerts.py)'
-        res = sdclient.create_alert(alert_obj=a)
+        if a['name'] in existing_alerts:
+            a['id'] = existing_alerts[a['name']]['id']
+            a['version'] = existing_alerts[a['name']]['version']
+            a['description'] += ' (updated via restore_alerts.py)'
+            res = sdclient.update_alert(a)
+            updated_count += 1
+        else:
+            a['description'] += ' (created via restore_alerts.py)'
+            res = sdclient.create_alert(alert_obj=a)
+            created_count += 1
         if not res[0]:
             print res[1]
             sys.exit(1)
 
-print 'All Alerts in ' + alerts_dump_file + ' created successfully.'
+print ('All Alerts in ' + alerts_dump_file + ' restored successfully (' +
+      str(created_count) + ' created, ' + str(updated_count) + ' updated)')


### PR DESCRIPTION
Recent issues have identified the need for the `update_alert()` function and also the ability to do a bulk creation of Alerts using a JSON file (the latter being accomplished via the new `restore_alerts.py` example.) In a recent update to https://github.com/draios/python-sdc-client/issues/26, a user identified that it would be useful to do bulk updates as well, such as to sync from a golden set maintained in a JSON file. This PR updates `restore_alerts.py` to cover this case as well.
