### PR TITLE
Fix tests for events

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,8 @@ script:
 - examples/list_dashboards.py XXX
 - examples/list_hosts.py XXX
 - examples/list_metrics.py XXX
-- examples/post_event.py XXX "test event name" -d "test event description"
-- examples/post_event_simple.py XXX "test event name" "test event description"
+- examples/post_event.py XXX "test_event_name" -d "test event description"
+- examples/post_event_simple.py XXX "test_event_name" "test event description"
 - examples/list_events.py XXX
 - examples/delete_event.py XXX
 - examples/print_data_retention_info.py XXX

--- a/examples/delete_event.py
+++ b/examples/delete_event.py
@@ -27,7 +27,7 @@ sdclient = SdcClient(sdc_token)
 #
 # Get the events that match a name
 #
-res = sdclient.get_events(name='test event')
+res = sdclient.get_events(name='test_event_name')
 
 if not res[0]:
 	print res[1]


### PR DESCRIPTION
After merging an unrelated enhancement, the Travis run showed the `delete_event` example failed. I traced it down to an event in the backend that's failing delete reasons yet to be explained (event ID=413658984227033090). However, it was an event that shouldn't have been flagged by `delete_event` in the first place. That is, the `post_event` examples were creating events with names "test event name" and `delete_event` was targeting all events with name "test event". However, I think due to the way ES search works, this was actually matching all items with names matching test OR event, which is why it was finding this rogue/unrelated event that wouldn't delete. I've now tightened all of this up by using underscores to make single-token names "test_event_name", so that way the examples will only create/delete their own stuff.