### PR TITLE
Include filterExpression (scope) when restoring backed-up Dashboards

### DIFF
--- a/examples/restore_dashboards.py
+++ b/examples/restore_dashboards.py
@@ -35,7 +35,7 @@ dashboard_conf_items = ['showAsType', 'filterRoot', 'linkMetrics',
                         'filterProcesses', 'isLegendExpanded', 'inhertitTimeNavigation',
                         'schema', 'sortAscending', 'mapDataLimit', 'metrics', 'filterExtNodes',
                         'sorting', 'name', 'sourceExploreView', 'items', 'showAs', 'eventsFilter',
-                        'timeMode', 'isShared', 'sourceDrilldownView']
+                        'timeMode', 'isShared', 'sourceDrilldownView', 'filterExpression']
 
 for info in zipf.infolist():
     data = zipf.read(info.filename)


### PR DESCRIPTION
When doing some Dashboard backup/restore recently, I found that this example had not been made hip to the recently-added ability to set scope (via `filterExpression ` parameter) in Dashboards. This  PR handles that.

I just tested it out ok myself and automation has passed. Since it's such a small change I'm going to go ahead and merge.
