### PR TITLE
Use yaml for agent config content

### DIFF
--- a/examples/get_agents_config.py
+++ b/examples/get_agents_config.py
@@ -24,7 +24,7 @@ sdc_token = sys.argv[1]
 #
 # Instantiate the SDC client
 #
-sdclient = SdcClient(sdc_token, 'https://app-staging.sysdigcloud.com')
+sdclient = SdcClient(sdc_token, 'https://app.sysdigcloud.com')
 
 #
 # Get the configuration

--- a/examples/get_agents_config.py
+++ b/examples/get_agents_config.py
@@ -38,6 +38,9 @@ if res[0]:
     if not("files" in res[1]) or len(res[1]["files"]) == 0:
         print "No current auto configuration"
     else:
+        print "Current contents of config file:"
+        print "--------------------------------"
         print res[1]["files"][0]["content"]
+        print "--------------------------------"
 else:
     print res[1]

--- a/examples/get_agents_config.py
+++ b/examples/get_agents_config.py
@@ -35,6 +35,9 @@ res = sdclient.get_agents_config()
 # Return the result
 #
 if res[0]:
+    if not("files" in res[1]) or len(res[1]["files"]) == 0:
+        print "No current auto configuration"
+    else:
         print res[1]["files"][0]["content"]
 else:
     print res[1]

--- a/examples/get_agents_config.py
+++ b/examples/get_agents_config.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Get the sysdig cloud agents configuration as a json file and print it on the screen.
+# Get the sysdig cloud agents configuration as yaml and print it on the screen.
 # Agents configuration settings can be managed in a centralized way through the API
 # This script downloads the settings and its result can be edited and the used from
 # the set_agents_config script.
@@ -8,7 +8,6 @@
 
 import os
 import sys
-import json
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.realpath(sys.argv[0])), '..'))
 from sdcclient import SdcClient
 
@@ -36,6 +35,6 @@ res = sdclient.get_agents_config()
 # Return the result
 #
 if res[0]:
-        print json.dumps(res[1], indent=2)
+        print res[1]["files"][0]["content"]
 else:
     print res[1]

--- a/examples/set_agents_config.py
+++ b/examples/set_agents_config.py
@@ -1,15 +1,15 @@
 #!/usr/bin/env python
 #
 # Set the sysdig cloud agents configuration.
-# This script takes a user token and a json file as input, and pushes the configuration 
-# in the json file to the user.
-# Typically, you want to create the json file by using the get_agents_config.py script,
+# This script takes a user token and a yaml configuration file as input, and pushes the configuration
+# in the yaml config file to the user.
+# Typically, you want to first read the config file using the get_agents_config.py script,
 # edit it and then push it back with this script.
 #
 
 import os
 import sys
-import json
+import yaml
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.realpath(sys.argv[0])), '..'))
 from sdcclient import SdcClient
 
@@ -17,7 +17,7 @@ from sdcclient import SdcClient
 # Parse arguments
 #
 if len(sys.argv) != 3:
-    print 'usage: %s <sysdig-token> <config-json-file>' % sys.argv[0]
+    print 'usage: %s <sysdig-token> <agent-yaml-config-file>' % sys.argv[0]
     print 'You can find your token at https://app.sysdigcloud.com/#/settings/user'
     sys.exit(1)
 
@@ -26,18 +26,21 @@ sdc_token = sys.argv[1]
 #
 # Load the config file
 #
-with open(sys.argv[2]) as cfile:    
-    conf = json.load(cfile)
-
+with open(sys.argv[2]) as cfile:
+    yaml_conf = cfile.read()
+    # Verify that the content is valid yaml
+    parsed_yaml_conf = yaml.load(yaml_conf)
 #
 # Instantiate the SDC client
 #
 sdclient = SdcClient(sdc_token, 'https://app-staging.sysdigcloud.com')
 
+json = {"files": [{"filter": "*", "content": yaml_conf}]}
+
 #
 # Push the configuration
 #
-res = sdclient.set_agents_config(conf)
+res = sdclient.set_agents_config(json)
 
 #
 # Check if everything went well

--- a/examples/set_agents_config.py
+++ b/examples/set_agents_config.py
@@ -33,7 +33,7 @@ with open(sys.argv[2]) as cfile:
 #
 # Instantiate the SDC client
 #
-sdclient = SdcClient(sdc_token, 'https://app-staging.sysdigcloud.com')
+sdclient = SdcClient(sdc_token, 'https://app.sysdigcloud.com')
 
 json = {"files": [{"filter": "*", "content": yaml_conf}]}
 

--- a/examples/user_team_mgmt.py
+++ b/examples/user_team_mgmt.py
@@ -21,7 +21,7 @@ sdc_token = sys.argv[1]
 #
 # Instantiate the SDC client
 #
-sdclient = SdcClient(sdc_token, sdc_url='https://app-staging.sysdigcloud.com')
+sdclient = SdcClient(sdc_token, sdc_url='https://app.sysdigcloud.com')
 
 team_name = sys.argv[2]
 user_name = sys.argv[3]


### PR DESCRIPTION
set_agents_config.py/get_agents_config.py currently read and write the
raw json that's inside the api body. This isn't very user friendly.

Change them to work directly with the agent config-as-yaml content
instead. get_agents_config.py will extract the yaml confg from the json
response and print it. set_agents_config.py will take the agent config
from the file on the command line, verify that it can be parsed as yaml,
wrap it in json, and PUT it.