### PR TITLE
Restore Sphinx auto-creation of Monitor function docs

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -16,7 +16,7 @@ This page documents the functions available in the `Python Script Library <https
 Function List
 =============
 .. py:module:: sdcclient
-.. autoclass:: SdMonClient
+.. autoclass:: SdMonitorClient
    :members:
    :inherited-members:
    :undoc-members:


### PR DESCRIPTION
Well, this is embarrassing. :)  It looks like a typo in the Sphinx config has made it such that the docs for Monitor-specific functions have not been getting generated since October, 2017:

```
# make html
Running Sphinx v1.3.6
loading pickled environment... done
building [mo]: targets for 0 po files that are out of date
building [html]: targets for 0 source files that are out of date
updating environment: 0 added, 1 changed, 0 removed
reading sources... [100%] index
/home/phil/python-sdc-client/doc/index.rst:19: WARNING: autodoc: failed to import class u'SdMonClient' from module u'sdcclient'; the following exception was raised:
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/sphinx/ext/autodoc.py", line 393, in import_object
    obj = self.get_attr(obj, part)
  File "/usr/lib/python2.7/dist-packages/sphinx/ext/autodoc.py", line 289, in get_attr
    return safe_getattr(obj, name, *defargs)
  File "/usr/lib/python2.7/dist-packages/sphinx/util/inspect.py", line 115, in safe_getattr
    raise AttributeError(name)
AttributeError: SdMonClient
looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
writing output... [100%] index
generating indices... genindex py-modindex
writing additional pages... search
copying static files... WARNING: html_static_path entry u'/home/phil/python-sdc-client/doc/_static' does not exist
done
copying extra files... done
dumping search index in English (code: en) ... done
dumping object inventory... done
build succeeded, 2 warnings.

Build finished. The HTML pages are in _build/html.
```

This PR fixes the typo. I've tested with a local `make html` & viewed them in a browser.
