### PR TITLE
Remove switch_user_team() method, as it never worked and can't work as described

### DIFF
--- a/sdcclient/_client.py
+++ b/sdcclient/_client.py
@@ -941,27 +941,6 @@ class _SdcCommon(object):
         else:
             return [True, None]
 
-    def switch_user_team(self, new_team_id):
-        '''**Description**
-            Switches the current user context to the specified team. In other words, this function makes it possible to start operating in the context of a different team without having to use the token of that team.
-
-        **Arguments**
-            - **new_team_id**: the numeric ID of the team (such as returned by :func:`~SdcClient.get_team_ids`) to switch to.
-        '''
-        res = self.get_user_info()
-        if not res[0]:
-            return res
-
-        myuinfo = res[1]['user']
-        myuinfo['currentTeam'] = new_team_id
-        uid = myuinfo['id']
-
-        res = requests.put(self.url + '/api/user/' + str(uid), headers=self.hdrs, data=json.dumps(myuinfo), verify=self.ssl_verify)
-        if not self._checkResponse(res):
-            return [False, self.lasterr]
-        else:
-            return [True, None]
-
     def get_agents_config(self):
         res = requests.get(self.url + '/api/agents/config', headers=self.hdrs, verify=self.ssl_verify)
         if not self._checkResponse(res):


### PR DESCRIPTION
https://github.com/draios/python-sdc-client/issues/53 points out that the `switch_user_team()` method doesn't work as described and should be deleted. This method is also not referenced in the `examples` nor automated `tests`.

I did some searching and confirmed that this method was basically DOA. It first appeared in https://github.com/draios/python-sdc-client/commit/9f7d3cf7eb88951250727c4df275a744a6bb659d on November 3, 2016, which was part of a series of commits to add Teams functionality to create https://github.com/draios/sysdig-kube-watcher. However, the `switch_user_team()` method was never used by Kubewatcher, and indeed, in Kubewatcher commit https://github.com/draios/sysdig-kube-watcher/blob/d1cb4eb33ab5214994c5a3924485c29511504070/main.py#L207 on November 5, 2016, the approach was used that's described in https://github.com/draios/python-sdc-client/issues/53: A new client is created with a separate token for the appropriate team! Therefore, my guess is that when @ldegio was creating Kubewatcher, he realized `switch_user_team()` wasn't going to do the trick but probably just forgot to circle back and delete it from the Python client.
