### PR TITLE
SMPROD-1326: Example to add all users to Secure Operations team

### DIFF
--- a/examples/add_users_to_secure.py
+++ b/examples/add_users_to_secure.py
@@ -44,14 +44,12 @@ SECURE_TEAM_ROLE = 'ROLE_TEAM_EDIT'
 #
 sdclient = SdcClient(sdc_token, sdc_url='https://app.sysdigcloud.com')
 
-res = sdclient.get_teams(SECURE_TEAM_NAME)
+res = sdclient.list_memberships(SECURE_TEAM_NAME)
 
 if res[0] == False:
-    print 'Unable to get teams: ', res[1]
+    print 'Unable to get memberships for ' + SECURE_TEAM_NAME + ' team: ', res[1]
     sys.exit(1)
-memberships = {}
-for secure_team_user in res[1][0]['userRoles']:
-    memberships[secure_team_user['userId']] = secure_team_user['role']
+memberships = res[1]
 
 res = sdclient.get_users()
 
@@ -65,14 +63,13 @@ all_users = res[1]
 # rather than ID, so convert the IDs.
 #
 for user in all_users:
-    if user['id'] in memberships:
+    if user['username'] in memberships:
         print 'Will preserve existing membership for: ' + user['username']
-        memberships[user['username']] = memberships.pop(user['id'])
     else:
         print 'Will add new member: ' + user['username']
         memberships[user['username']] = SECURE_TEAM_ROLE
 
-res = sdclient.edit_team(SECURE_TEAM_NAME, memberships=memberships)
+res = sdclient.save_memberships(SECURE_TEAM_NAME, memberships=memberships)
 if res[0] == False:
     print 'Could not edit team:', res[1], '. Exiting.'
     sys.exit(1)

--- a/examples/add_users_to_secure.py
+++ b/examples/add_users_to_secure.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python
+#
+# Make sure all users are members of the Secure Operations team.
+#
+# As of when this script was written, there is only one team for
+# all Secure users. Newly-created users that land in the default
+# team for Monitor (such as those created via the API) will
+# therefore not be in the Secure Operations team. If you have an
+# environment where you want all users to have both Monitor and
+# Secure access by default, you could run this script periodically
+# (e.g. as a cron job) to make sure any such users are made part
+# of the Secure Operations team as well.
+#
+
+import os
+import sys
+import json
+import logging
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.realpath(sys.argv[0])), '..'))
+from sdcclient import SdcClient
+
+#
+# Parse arguments
+#
+if len(sys.argv) != 2:
+    print 'usage: %s <sysdig-token>' % sys.argv[0]
+    print 'You can find your token at https://app.sysdigcloud.com/#/settings/user'
+    sys.exit(1)
+
+sdc_token = sys.argv[1]
+
+SECURE_TEAM_NAME = 'Secure Operations'
+
+#
+# As of when this script was written, the Secure Operations team does
+# not have the concepts of RBAC roles like "Read User" vs. "Edit User".
+# Rather, all members of the Secure team have full visibility within
+# Secure, which is associated with ROLE_TEAM_EDIT.
+#
+SECURE_TEAM_ROLE = 'ROLE_TEAM_EDIT'
+
+#
+# Instantiate the SDC client
+#
+sdclient = SdcClient(sdc_token, sdc_url='https://app.sysdigcloud.com')
+
+res = sdclient.get_teams(SECURE_TEAM_NAME)
+
+if res[0] == False:
+    print 'Unable to get teams: ', res[1]
+    sys.exit(1)
+memberships = {}
+for secure_team_user in res[1][0]['userRoles']:
+    memberships[secure_team_user['userId']] = secure_team_user['role']
+
+res = sdclient.get_users()
+
+if res[0] == False:
+    print 'Unable to get users: ', res[1]
+    sys.exit(1)
+all_users = res[1]
+
+#
+# The memberships passed into edit_team() are based on username
+# rather than ID, so convert the IDs.
+#
+for user in all_users:
+    if user['id'] in memberships:
+        print 'Will preserve existing membership for: ' + user['username']
+        memberships[user['username']] = memberships.pop(user['id'])
+    else:
+        print 'Will add new member: ' + user['username']
+        memberships[user['username']] = SECURE_TEAM_ROLE
+
+res = sdclient.edit_team(SECURE_TEAM_NAME, memberships=memberships)
+if res[0] == False:
+    print 'Could not edit team:', res[1], '. Exiting.'
+    sys.exit(1)
+else:
+    print 'Finished syncing memberships of "' + SECURE_TEAM_NAME + '" team'
+
+sys.exit(0)


### PR DESCRIPTION
SMPROD-1326 highlights a limitation we have at the moment with the Secure Operations team. Users created in Monitor via the API (such as those created as a side-effect of the LDAP Mapping feature that's currently in beta) land in the default team for Monitor. But granting them access to Secure would typically require an Admin to add them to the Secure Operations team in the Secure UI as a separate step. While waiting on a more elegant option, users who effectively want all such Monitor users to also land in Secure could instead run this example in a cron job. That way any users recently auto-created on the Monitor side (once again, such as via LDAP Mapping) could be auto-added to Secure Operations as well.

@aponjavic: I put you down as a Reviewer because I want to double check my interpretation of the limitations of the Secure Operations team. Based on what I observed in the Secure UI and what's in https://sysdig.atlassian.net/browse/SSPROD-35 and @lessenadam's demo video linked from there, it looks pretty clear that all members of the Secure Operations team are always going to have the EDIT role, so that's what I've done here (as opposed to, say, making the role into an option the user could pick when they run the script.) Please let me know if I've misinterpreted this. Thanks.