### PR TITLE
Preserve enabled user attribute when editing

### DIFF
--- a/sdcclient/_client.py
+++ b/sdcclient/_client.py
@@ -647,6 +647,7 @@ class _SdcCommon(object):
             'agentInstallParams': user['agentInstallParams'],
             'systemRole': systemRole if systemRole else user['systemRole'],
             'username': user_email,
+            'enabled': user.get('enabled', False),
             'version': user['version']
             }
 


### PR DESCRIPTION
When issuing a `edit_user` using a `ROLE_CUSTOMER` credentials against a user from the same account, `enabled` field needs to be preserved.