### PR TITLE
Catch exception for non-JSON items in Dashboard ZIP

### DIFF
--- a/examples/restore_dashboards.py
+++ b/examples/restore_dashboards.py
@@ -39,12 +39,18 @@ dashboard_conf_items = ['showAsType', 'filterRoot', 'linkMetrics',
 
 for info in zipf.infolist():
     data = zipf.read(info.filename)
-    j = json.loads(data)
+    try:
+        j = json.loads(data)
+    except ValueError:
+        print 'Non-JSON item found in ZIP: ' + info.filename + ' (skipping)'
+        continue
     k = {}
     for item in j.keys():
         if item in dashboard_conf_items:
             k[item] = j[item]
      
     res = sdclient.create_dashboard_with_configuration(k)
-    if res[0] == False:
+    if res[0]:
+        print 'Restored Dashboard named: ' + j['name']
+    else:
         print "Dashboard creation failed for dashboard name %s with error %s" % (j['name'], res[1])


### PR DESCRIPTION
@harrysx had a use case where he'd taken a ZIP of dashboards originally created from `download_dashboards.py`, unzipped it to trim it down to a subset, then re-zipped it. The `restore_dashboards.py` script ultimately choked on this with the error:

```
Traceback (most recent call last):
  File "restore_dashboards.py", line 42, in <module>
    j = json.loads(data)
  File "/usr/lib/python2.7/json/__init__.py", line 339, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python2.7/json/decoder.py", line 364, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib/python2.7/json/decoder.py", line 382, in raw_decode
    raise ValueError("No JSON object could be decoded")
ValueError: No JSON object could be decoded
```

The contents of the repackaged ZIP:

```
# unzip -l harry_k8s_dashboards.zip
Archive:  harry_k8s_dashboards.zip
  Length      Date    Time    Name
---------  ---------- -----   ----
        0  2018-08-03 11:52   k8s_dashboards/
     6148  2018-08-03 11:56   k8s_dashboards/.DS_Store
        0  2018-08-10 10:36   __MACOSX/
        0  2018-08-10 10:36   __MACOSX/k8s_dashboards/
      120  2018-08-03 11:56   __MACOSX/k8s_dashboards/._.DS_Store
     1880  2018-08-03 12:00   k8s_dashboards/7110
      474  2018-08-03 12:00   __MACOSX/k8s_dashboards/._7110
---------                     -------
     8622                     7 files
```

The previous dumb version of the restore script just expects to find only valid JSON files in the ZIP. That's fine if one could assume only unmodified ZIPs that came from the `download` script, but this repackaging is innocent enough that we should be able to handle it.

This repackaged ZIP tripped up the `restore` in a couple ways:

1.  The bare directory entry `k8s_dashboards/`. One could exclude such entries if repackaging with the `-D` option, but it's not default behavior.
2. The excess Mac files like `._.DS_Store` are in there regardless.

This PR gets around all these issues by simply catching the exception from any non-JSON junk found in the ZIP, then notes what it was and that it's being skipped.

While I was at it, I also added a line to print the name of each Dashboard successfully restored.
