### PR TITLE
Remove unused parameter

### DIFF
--- a/sdcclient/_client.py
+++ b/sdcclient/_client.py
@@ -649,7 +649,6 @@ class _SdcCommon(object):
             return res
         user = res[1]
         reqbody = {
-            'agentInstallParams': user['agentInstallParams'],
             'systemRole': systemRole if systemRole else user['systemRole'],
             'username': user_email,
             'enabled': user.get('enabled', False),


### PR DESCRIPTION
`agentInstallParams` is no returned anymore at GET `api/users` and it would be ignored as part of the PUT request

This was currently failing at our staging environment. We should schedule the release of this patch among the backend release to saas.