### PR TITLE
Add missing import

### DIFF
--- a/sdcclient/_secure.py
+++ b/sdcclient/_secure.py
@@ -2,6 +2,7 @@ import json
 import datetime
 import requests
 import shutil
+import os
 
 from sdcclient._common import _SdcCommon
 


### PR DESCRIPTION
Got dropped as a part of the secure/monitor split in https://github.com/draios/python-sdc-client/pull/74