### PR TITLE
Consolidate and simplify tests using Sysdig agent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,10 @@ install:
   - sudo apt-get install linux-headers-$(uname -r) dkms gcc-multilib g++-multilib
   - pip install pyyaml requests
 script:
+- bash test/start_agent.sh
 - bash test/test_monitor_apis.sh
 - bash test/test_secure_apis.sh
+- bash test/stop_agent.sh
 notifications:
   slack:
     secure: GJ0H2wAaW67t3+x+cCjOVLw/b+YAZjH9rebAfluCFJklJS9u+V6/qqIyiNDAkMPIcgilFyhiyOQCZYXapgthQ1ieFbZZo//mrRtuGo2wuxCAwcOx2mXAZpZ4I5b3+Q/znVqSuqkwFRid1d138z4TW7sYSIburouDX3QUNoUOy+g7VJxCFQCcqlN8LYxGJHQYdOZa9zIGCtKrOtZ/B8C1TLgXmDMwAAVNO2WzL4GiBTLCGuMsQWMTLw2Qmv1ayZPztmeDWo1C9oa7HIH8Bg2YVjssR87el28X+EqEO533mgYjPmW2/hii30WVFOUE5hMdvKeQLBvy5N3/OCch1np0RQBd8eYEtaPv38rc5L2wAnUq9G5Zzr252z7vnwSLi6lap9jWU8tOerSTEPU+jG05PnuCnufVDXVNPyiPsH6BDP4qxHmLjooNpxfe63Df7NNyUi2I3QoroLj/UzI7zZVQjJEqsTrr5BbsH4z6NTGY91+ZqobBn62+hV3ESAam0ivQgC7s2AKko0qkKyIUGjj7ozU8ebo1UpagNvKC/J9szMqtdXJgKtG8BeonyLMeN6MEEyEvcMJbB4dCcfet+1Sb9AZWnGvYVdajhVLb1HE6OrbzZyhC3KqCe06J9O5BCY9ncy+l16i7MyIfcKTibHQlxPU+Id/VijD97JSRXxnd2i4=

--- a/test/start_agent.sh
+++ b/test/start_agent.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+# Start an agent using the testing account API key to send some data
+docker run -d -it --rm --name sysdig-agent --privileged --net host --pid host -e COLLECTOR=collector-staging.sysdigcloud.com -e ACCESS_KEY=$PYTHON_SDC_TEST_ACCESS_KEY -v /var/run/docker.sock:/host/var/run/docker.sock  -v /dev:/host/dev -v /proc:/host/proc:ro -v /boot:/host/boot:ro -v /lib/modules:/host/lib/modules:ro -v /usr:/host/usr:ro --shm-size=350m sysdig/agent
+
+# make sure the agent starts sending data and the backend makes it available via API
+sleep 60

--- a/test/stop_agent.sh
+++ b/test/stop_agent.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+docker logs sysdig-agent
+docker stop sysdig-agent

--- a/test/test_monitor_apis.sh
+++ b/test/test_monitor_apis.sh
@@ -7,12 +7,6 @@ SCRIPTDIR=$(dirname $SCRIPT)
 
 export SDC_URL=https://app-staging.sysdigcloud.com
 
-# Start an agent using the testing account API key to send some data
-docker run -d -it --rm --name sysdig-agent --privileged --net host --pid host -e COLLECTOR=collector-staging.sysdigcloud.com -e ACCESS_KEY=$PYTHON_SDC_TEST_ACCESS_KEY -v /var/run/docker.sock:/host/var/run/docker.sock  -v /dev:/host/dev -v /proc:/host/proc:ro -v /boot:/host/boot:ro -v /lib/modules:/host/lib/modules:ro -v /usr:/host/usr:ro --shm-size=350m sysdig/agent
-
-# make sure the agent starts sending data and the backend makes it available via API
-sleep 60
-
 AGENT_HOSTNAME=$(hostname -s)
 SESSION_UUID=$(head -c 32 /dev/urandom | tr -dc 'a-zA-Z0-9')
 ALERT_NAME=python-test-alert-$SESSION_UUID
@@ -51,6 +45,3 @@ date; $SCRIPTDIR/../examples/create_sysdig_capture.py $PYTHON_SDC_TEST_MONITOR_A
 date; $SCRIPTDIR/../examples/notification_channels.py -c $CHANNEL_NAME $PYTHON_SDC_TEST_MONITOR_API_TOKEN
 date; $SCRIPTDIR/../examples/user_team_mgmt.py $PYTHON_SDC_TEST_MONITOR_API_TOKEN $TEAM_NAME example-user@example-domain.com
 date; $SCRIPTDIR/../examples/user_team_mgmt_extended.py $PYTHON_SDC_TEST_MONITOR_API_TOKEN $TEAM_NAME example-user@example-domain.com
-
-docker stop sysdig-agent
-

--- a/test/test_monitor_apis.sh
+++ b/test/test_monitor_apis.sh
@@ -7,9 +7,11 @@ SCRIPTDIR=$(dirname $SCRIPT)
 
 export SDC_URL=https://app-staging.sysdigcloud.com
 
-docker run -d -it --rm --name sysdig-agent --privileged --net host --pid host -e COLLECTOR=collector-staging.sysdigcloud.com -e ACCESS_KEY=$PYTHON_SDC_TEST_ACCESS_KEY -v /var/run/docker.sock:/host/var/run/docker.sock  -v /dev:/host/dev -v /proc:/host/proc:ro -v /boot:/host/boot:ro -v /lib/modules:/host/lib/modules:ro -v /usr:/host/usr:ro sysdig/agent
+# Start an agent using the testing account API key to send some data
+docker run -d -it --rm --name sysdig-agent --privileged --net host --pid host -e COLLECTOR=collector-staging.sysdigcloud.com -e ACCESS_KEY=$PYTHON_SDC_TEST_ACCESS_KEY -v /var/run/docker.sock:/host/var/run/docker.sock  -v /dev:/host/dev -v /proc:/host/proc:ro -v /boot:/host/boot:ro -v /lib/modules:/host/lib/modules:ro -v /usr:/host/usr:ro --shm-size=350m sysdig/agent
 
-sleep 20
+# make sure the agent starts sending data and the backend makes it available via API
+sleep 60
 
 AGENT_HOSTNAME=$(hostname -s)
 SESSION_UUID=$(head -c 32 /dev/urandom | tr -dc 'a-zA-Z0-9')

--- a/test/test_secure_apis.sh
+++ b/test/test_secure_apis.sh
@@ -137,7 +137,9 @@ FOUND=0
 for i in $(seq 10); do
     sleep 10
     sudo touch /bin/some-file.txt
+
     EVTS=`$SCRIPTDIR/../examples/get_secure_policy_events.py $PYTHON_SDC_TEST_API_TOKEN 60`
+    
     if [[ "$EVTS" != "" ]]; then
        FOUND=1
        break;
@@ -145,6 +147,6 @@ for i in $(seq 10); do
 done
 
 if [[ $FOUND == 0 ]]; then
-   echo "Did not find any policy events after 60 seconds of wait"
+   echo "Did not find any policy events after 10 attempts..."
    exit 1
 fi

--- a/test/test_secure_apis.sh
+++ b/test/test_secure_apis.sh
@@ -131,12 +131,7 @@ fi
 
 echo $OUT
 
-# Start an agent using the testing account API key and trigger an event
-docker run -d -it --rm --name sysdig-agent --privileged --net host --pid host -e COLLECTOR=collector-staging.sysdigcloud.com -e ACCESS_KEY=$PYTHON_SDC_TEST_ACCESS_KEY -v /var/run/docker.sock:/host/var/run/docker.sock  -v /dev:/host/dev -v /proc:/host/proc:ro -v /boot:/host/boot:ro -v /lib/modules:/host/lib/modules:ro -v /usr:/host/usr:ro --shm-size=350m sysdig/agent
-
-# make sure the agent starts sending data and the backend makes it available via API
-sleep 60
-
+# Trigger an event
 sudo touch /bin/some-file.txt
 
 # make sure the agent sends the policy event and the backend makes it available via API

--- a/test/test_secure_apis.sh
+++ b/test/test_secure_apis.sh
@@ -135,11 +135,11 @@ echo $OUT
 FOUND=0
 
 for i in $(seq 10); do
-    sleep 10
     sudo touch /bin/some-file.txt
+    sleep 10
 
     EVTS=`$SCRIPTDIR/../examples/get_secure_policy_events.py $PYTHON_SDC_TEST_API_TOKEN 60`
-    
+
     if [[ "$EVTS" != "" ]]; then
        FOUND=1
        break;

--- a/test/test_secure_apis.sh
+++ b/test/test_secure_apis.sh
@@ -131,17 +131,18 @@ fi
 
 echo $OUT
 
-# Trigger an event
-sudo touch /bin/some-file.txt
+# Trigger some events
+FOUND=0
 
-# make sure the agent sends the policy event and the backend makes it available via API
-sleep 60
-
-EVTS=`$SCRIPTDIR/../examples/get_secure_policy_events.py $PYTHON_SDC_TEST_API_TOKEN 90`
-
-if [[ "$EVTS" != "" ]]; then
-    FOUND=1
-fi
+for i in $(seq 10); do
+    sleep 10
+    sudo touch /bin/some-file.txt
+    EVTS=`$SCRIPTDIR/../examples/get_secure_policy_events.py $PYTHON_SDC_TEST_API_TOKEN 60`
+    if [[ "$EVTS" != "" ]]; then
+       FOUND=1
+       break;
+    fi
+done
 
 if [[ $FOUND == 0 ]]; then
    echo "Did not find any policy events after 60 seconds of wait"

--- a/test/test_secure_apis.sh
+++ b/test/test_secure_apis.sh
@@ -143,9 +143,6 @@ if [[ "$EVTS" != "" ]]; then
     FOUND=1
 fi
 
-docker logs sysdig-agent
-docker stop sysdig-agent
-
 if [[ $FOUND == 0 ]]; then
    echo "Did not find any policy events after 60 seconds of wait"
    exit 1


### PR DESCRIPTION
1. Use a single command line to launch Sysdig agent container
2. Wait longer after the launch, to make data is made available via Sysdig API
3. Simplify test for policy events (wait longer instead of polling)