### PR TITLE
Get image profiles from secure

### DIFF
--- a/examples/list_profiles.py
+++ b/examples/list_profiles.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+#
+# List the current set of image profiles.
+#
+
+import os
+import sys
+import json
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.realpath(sys.argv[0])), '..'))
+from sdcclient import SdSecureClient
+
+
+def usage():
+    print('usage: %s <secure-endpoint> <sysdig-token>' % sys.argv[0])
+    sys.exit(1)
+
+
+#
+# Check number of parameters
+#
+if len(sys.argv) < 2:
+    usage()
+
+sdc_endpoint = sys.argv[1]
+sdc_token   = sys.argv[2]
+
+#
+# Instantiate the SDC client
+#
+sdclient = SdSecureClient(sdc_token, sdc_endpoint)
+
+#
+# Retrieve all the image profiles
+#
+ok, res = sdclient.list_image_profiles()
+
+
+if not ok:
+    print(res)
+    sys.exit(1)
+
+
+# Strip the surrounding json to only keep the list of profiles
+res = res['profiles']
+
+for profile in res:
+    print("ID: {}, Name: {}".format(profile["profileId"], profile["imageName"]))

--- a/sdcclient/_secure.py
+++ b/sdcclient/_secure.py
@@ -1017,7 +1017,7 @@ class SdSecureClient(_SdcCommon):
             return [False, self.lasterr]
 
         
-        matched_profiles = self.__get_mathced_profileIDs(profileId, image_profiles['profiles'])
+        matched_profiles = self.__get_matched_profileIDs(profileId, image_profiles['profiles'])
         
         # Profile ID not found
         if len(matched_profiles) == 0:
@@ -1039,7 +1039,7 @@ class SdSecureClient(_SdcCommon):
             return [False, matched_profiles]
 
 
-    def __get_mathced_profileIDs(self, requested_profile, profile_list):
+    def __get_matched_profileIDs(self, requested_profile, profile_list):
         '''
         **Description**
             Helper function for  retrieving the list of matching profile

--- a/sdcclient/_secure.py
+++ b/sdcclient/_secure.py
@@ -1059,10 +1059,10 @@ class SdSecureClient(_SdcCommon):
         
         **Arguments**
             - the requested profile Id (string)
-            - List of dictionary, where each discionary conatins the profile information 
+            - List of dictionary, where each dictionary contains the profile information
     
         **Success Return Value**
-            List of dictionary, where each dicionary represents a profile with the ID prefix substring
+            List of dictionary, where each dictionary represents a profile with the ID prefix substring
             matching the requested one
         
         **Content structure of the profile_list parameter**

--- a/sdcclient/_secure.py
+++ b/sdcclient/_secure.py
@@ -615,6 +615,20 @@ class SdSecureClient(_SdcCommon):
         res = requests.get(self.url + '/api/policies', headers=self.hdrs, verify=self.ssl_verify)
         return self._request_result(res)
 
+    def list_image_profiles(self):
+        '''**Description**
+            List the current set of image profiles.
+
+        **Arguments**
+            - None
+
+        **Success Return Value**
+            A JSON object containing the number and details of each profile.
+
+        '''
+        res = requests.get(self.url + '/api/profiling/v1/secure/profileGroups/0/profiles', headers=self.hdrs, verify=self.ssl_verify)
+        return self._request_result(res)
+
     def get_policy_priorities(self):
         '''**Description**
             Get a list of policy ids in the order they will be evaluated.

--- a/sdcclient/_secure.py
+++ b/sdcclient/_secure.py
@@ -983,7 +983,7 @@ class SdSecureClient(_SdcCommon):
             - None
 
         **Success Return Value**
-            A JSON object containing the number and details of each profile.
+            A JSON object containing the details of each profile.
 
         '''
         url = "{url}/api/profiling/v1/secure/profileGroups/0/profiles".format(
@@ -1004,8 +1004,8 @@ class SdSecureClient(_SdcCommon):
         **Success Return Value**
             A JSON object containing the description of the image profile. If there is no image profile with
             the given name, returns False. Moreover, it could happen that more than one profile IDs have a collision.
-            It is due to the fact that even a partial profile ID can be passed and interpreted; in this case a set of
-            collision profiles is returned, and the full complete ID string is printed. In this case, it is returned
+            It is due to the fact that a partial profile ID can be passed and interpreted; in this case a set of
+            collision profiles is returned, and the full complete ID string is printed. In this case, it returns
             false.
 
         '''

--- a/sdcclient/_secure.py
+++ b/sdcclient/_secure.py
@@ -996,7 +996,7 @@ class SdSecureClient(_SdcCommon):
 
     def get_image_profile(self, profileId):
         '''**Description**
-            Find the iamge profile with a (partial) profile ID <profileId> and return its json description.
+            Find the image profile with a (partial) profile ID <profileId> and return its json description.
 
         **Arguments**
             - name: the name of the image profile to fetch
@@ -1040,8 +1040,20 @@ class SdSecureClient(_SdcCommon):
 
 
     def __get_mathced_profileIDs(self, requested_profile, profile_list):
+        '''
+        **Description**
+            Helper function for  retrieving the list of matching profile
+        
+            **Arguments**
+            - the requested profile Id (string)
+            - List of dictionary, where each discionary conatins the profile information 
+    
+        **Success Return Value**
+            List of dictionary, where each dicionary represents a profile with the ID prefix substring
+            matching the requested one
+        '''
 
-        matchedIDs = []
+        matched_profiles = []
 
         request_len = len(requested_profile)
         for profile in profile_list:
@@ -1050,7 +1062,7 @@ class SdSecureClient(_SdcCommon):
             str_len_match = min(len(profile), request_len)
 
             if profile['profileId'][0:str_len_match] == requested_profile[0:str_len_match]:
-                matchedIDs.append(profile)
+                matched_profiles.append(profile)
 
-        return matchedIDs
+        return matched_profiles
 

--- a/sdcclient/_secure.py
+++ b/sdcclient/_secure.py
@@ -615,20 +615,6 @@ class SdSecureClient(_SdcCommon):
         res = requests.get(self.url + '/api/policies', headers=self.hdrs, verify=self.ssl_verify)
         return self._request_result(res)
 
-    def list_image_profiles(self):
-        '''**Description**
-            List the current set of image profiles.
-
-        **Arguments**
-            - None
-
-        **Success Return Value**
-            A JSON object containing the number and details of each profile.
-
-        '''
-        res = requests.get(self.url + '/api/profiling/v1/secure/profileGroups/0/profiles', headers=self.hdrs, verify=self.ssl_verify)
-        return self._request_result(res)
-
     def get_policy_priorities(self):
         '''**Description**
             Get a list of policy ids in the order they will be evaluated.
@@ -988,3 +974,83 @@ class SdSecureClient(_SdcCommon):
             metrics="&metrics=" + json.dumps(metrics) if metrics else "")
         res = requests.get(url, headers=self.hdrs, verify=self.ssl_verify)
         return self._request_result(res)
+
+    def list_image_profiles(self):
+        '''**Description**
+            List the current set of image profiles.
+
+        **Arguments**
+            - None
+
+        **Success Return Value**
+            A JSON object containing the number and details of each profile.
+
+        '''
+        url = "{url}/api/profiling/v1/secure/profileGroups/0/profiles".format(
+            url = self.url
+        )
+
+        res = requests.get(url, headers=self.hdrs, verify=self.ssl_verify)
+        return self._request_result(res)
+
+
+    def get_image_profile(self, profileId):
+        '''**Description**
+            Find the iamge profile with a (partial) profile ID <profileId> and return its json description.
+
+        **Arguments**
+            - name: the name of the image profile to fetch
+
+        **Success Return Value**
+            A JSON object containing the description of the image profile. If there is no image profile with
+            the given name, returns False. Moreover, it could happen that more than one profile IDs have a collision.
+            It is due to the fact that even a partial profile ID can be passed and interpreted; in this case a set of
+            collision profiles is returned, and the full complete ID string is printed. In this case, it is returned
+            false.
+
+        '''
+
+        # RETRIEVE ALL THE IMAGE PROFILES
+        ok, image_profiles = self.list_image_profiles()
+
+        if not ok:
+            return [False, self.lasterr]
+
+        
+        matched_profiles = self.__get_mathced_profileIDs(profileId, image_profiles['profiles'])
+        
+        # Profile ID not found
+        if len(matched_profiles) == 0:
+            return [False, "No profile with ID {}".format(profileId)]
+        
+        # Principal workflow. Profile ID found
+        elif len(matched_profiles) == 1:
+            # Matched id. Return information
+            url = "{url}/api/profiling/v1/secure/profiles/{profileId}".format(
+                url = self.url,
+                profileId = matched_profiles[0]['profileId']
+            )
+            
+            res = requests.get(url, headers=self.hdrs, verify=self.ssl_verify)
+            return self._request_result(res)
+
+        # Collision detected. The full profile IDs are returned
+        elif len(matched_profiles) >= 2:
+            return [False, matched_profiles]
+
+
+    def __get_mathced_profileIDs(self, requested_profile, profile_list):
+
+        matchedIDs = []
+
+        request_len = len(requested_profile)
+        for profile in profile_list:
+
+            # get the length of the substring to match    
+            str_len_match = min(len(profile), request_len)
+
+            if profile['profileId'][0:str_len_match] == requested_profile[0:str_len_match]:
+                matchedIDs.append(profile)
+
+        return matchedIDs
+

--- a/sdcclient/_secure.py
+++ b/sdcclient/_secure.py
@@ -1017,6 +1017,19 @@ class SdSecureClient(_SdcCommon):
             return [False, self.lasterr]
 
         
+        '''
+        The content of the json stored in the image_profiles dictionary:
+
+        {
+            "offset": 0,
+            "limit": 99,
+            "canLoadMore": false,
+            "profiles": [
+            ...
+            ]
+        }
+        '''
+        
         matched_profiles = self.__get_matched_profileIDs(profileId, image_profiles['profiles'])
         
         # Profile ID not found
@@ -1044,13 +1057,86 @@ class SdSecureClient(_SdcCommon):
         **Description**
             Helper function for  retrieving the list of matching profile
         
-            **Arguments**
+        **Arguments**
             - the requested profile Id (string)
             - List of dictionary, where each discionary conatins the profile information 
     
         **Success Return Value**
             List of dictionary, where each dicionary represents a profile with the ID prefix substring
             matching the requested one
+        
+        **Content structure of the profile_list parameter**
+        This array of profiles contains all the relevant information. For the purposes of this function, only
+        the profileId field is relevant.
+        
+        [
+            {
+            "profileGroupId": 0,
+            "profileId": "00000000000000000000000000000000000000000000",
+            "profileVersion": 0,
+            "profileName": "AAA/BBB:XYZ@0000000000000000000000",
+            "imageId": "00000000000000000000000000000000000000000000",
+            "imageName": "AAA/BBB:XYZ",
+            "processesProposal": {
+                "subcategories": [
+                                    {
+                                    "name": "process",
+                                    "ruleName": "process - 00000000000000000000000000000000000000000000",
+                                    "ruleType": "PROCESS",
+                                    "score": 000
+                                    }
+                                ],
+                                "score": 000
+            },
+            "fileSystemProposal": {
+                "subcategories": [
+                                    {
+                                    "name": "filesystem",
+                                    "ruleName": "filesystem - 00000000000000000000000000000000000000000000",
+                                    "ruleType": "FILESYSTEM",
+                                    "score": 000
+                                    }
+                                ],
+                                "score": 000
+            },
+            "syscallProposal": {
+                "subcategories": [
+                                    {
+                                    "name": "syscalls",
+                                    "ruleName": "syscalls - 00000000000000000000000000000000000000000000",
+                                    "ruleType": "SYSCALL",
+                                    "score": 000
+                                    }
+                                ],
+                                "score": 000
+            },
+            "networkProposal": {
+                "subcategories": [
+                                    {
+                                    "name": "network",
+                                    "ruleName": "network - 00000000000000000000000000000000000000000000",
+                                    "ruleType": "NETWORK",
+                                    "score": 000
+                                    }
+                                ],
+                                "score": 000
+            },
+            "containerImagesProposal": {
+                "subcategories": [
+                                    {
+                                    "name": "container image",
+                                    "ruleName": "container image - 00000000000000000000000000000000000000000000",
+                                    "ruleType": "CONTAINER",
+                                    "score": 0
+                                    }
+                                ],
+                                "score": 0
+            },
+            "status": "STATUS_VALUE",
+            "score": 000
+            },
+            ...
+        ]
         '''
 
         matched_profiles = []


### PR DESCRIPTION
Add API helpers for retrieving information about Image profile.

Features:
1. Get a list of all image profiles in the scope
2. Get profile details by passing a (partial) profile ID

Others:
- Partial profile ID support
- Profile ID collision detection