### PR TITLE
SSPROD-2210: Added import_image and anchore_account to SDC CLI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
 - '2.7'
 install:
   - sudo apt-get install linux-headers-$(uname -r) dkms gcc-multilib g++-multilib
-  - pip install pyyaml requests
+  - pip install pyyaml requests requests_toolbelt
 script:
 - bash test/start_agent.sh
 - bash test/test_monitor_apis.sh

--- a/examples/get_anchore_users_account.py
+++ b/examples/get_anchore_users_account.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+#
+# Get a specific anchore user account
+#
+
+import os
+import sys
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.realpath(sys.argv[0])), '..'))
+from sdcclient import SdScanningClient
+
+
+def usage():
+    print('usage: %s <sysdig-token>' % sys.argv[0])
+    print('You can find your token at https://secure.sysdig.com/#/settings/user')
+    sys.exit(1)
+
+
+#
+# Parse arguments
+#
+if len(sys.argv) != 2:
+    usage()
+
+sdc_token = sys.argv[1]
+
+#
+# Instantiate the SDC client
+#
+sdclient = SdScanningClient(sdc_token, 'https://secure.sysdig.com')
+
+ok, res = sdclient.get_anchore_users_account()
+
+#
+# Return the result
+#
+if ok:
+    print("Anchore User Info %s" % res)
+else:
+    print(res)
+    sys.exit(1)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests
 pyaml
+requests_toolbelt

--- a/setup.py
+++ b/setup.py
@@ -8,5 +8,5 @@ setup(name='sdcclient',
       author_email='info@sysdig.com',
       license='MIT',
       packages=['sdcclient'],
-      install_requires=['requests', 'pyaml'],
+      install_requires=['requests', 'pyaml', 'requests_toolbelt'],
       zip_safe=False)


### PR DESCRIPTION
**Usage**

**Anchore User Account** 
```
from sdcclient._scanning import SdScanningClient
client = SdScanningClient('<token>', 'http://localhost:9040')
print(client.get_anchore_users_account())
[True, {'created_at': '2019-08-12T23:41:58Z', 'email': None, 'last_updated': '2019-08-12T23:41:58Z', 'name': 'tenant_1PLVMqZvrKDcMVRDTDtUL4dOki4', 'state': 'enabled', 'type': 'user'}]
```
This PR implements import_image and accounts API needed to do inline-scanning. Currently it is in a bash script here https://github.com/sysdiglabs/secure-inline-scan/blob/inline-scan/inline_scan.sh#L463

**Import Image**
```
from sdcclient._scanning import SdScanningClient
client = SdScanningClient('<token>', 'http://localhost:9040')
print(client.get_anchore_users_account())
[True, {'created_at': '2019-08-12T23:41:58Z', 'email': None, 'last_updated': '2019-08-12T23:41:58Z', 'name': 'tenant_1PLVMqZvrKDcMVRDTDtUL4dOki4', 'state': 'enabled', 'type': 'user'}]
```