### PR TITLE
Enable authentication with IBM Cloud IAM

### DIFF
--- a/sdcclient/__init__.py
+++ b/sdcclient/__init__.py
@@ -3,3 +3,4 @@ from sdcclient._monitor import SdMonitorClient
 from sdcclient._monitor_v1 import SdMonitorClientV1
 from sdcclient._secure import SdSecureClient
 from sdcclient._scanning import SdScanningClient
+from sdcclient._ibmcloud import SdIbmCloud

--- a/sdcclient/_ibmcloud.py
+++ b/sdcclient/_ibmcloud.py
@@ -1,0 +1,70 @@
+from time import sleep
+import requests
+
+class SdIbmCloud():
+    def __init__(self, apikey, url, resource):
+        self.apikey = apikey
+        self.url = url
+        self.resource = resource
+
+    def __get_iam_token(self, last_retry):
+        if '.test.' in self.url:
+            env_url = 'iam.test.cloud.ibm.com'
+        else:
+            env_url = 'iam.cloud.ibm.com'
+        response = requests.post(
+            'https://' + env_url + '/identity/token',
+            data={
+                'grant_type': 'urn:ibm:params:oauth:grant-type:apikey',
+                'response_type': 'cloud_iam',
+                'apikey': self.apikey
+            },
+            headers={
+                'Accept': 'application/json'
+            })
+        if response.status_code == 200:
+            return response.json()['access_token']
+        elif last_retry:
+            response.raise_for_status()
+        else:
+            print('IBM Cloud token auth error: ' + str(response.status_code))
+        return None
+
+    def get_iam_token(self):
+        retries = 0
+        max_retries = 3
+        while retries < max_retries:
+            retries += 1
+            auth_token = self.__get_iam_token(retries == max_retries)
+            if auth_token:
+                return auth_token
+            sleep(1)
+
+    def __get_get_guid(self, last_retry, auth_token):
+        response = requests.get(
+            'https://resource-controller.cloud.ibm.com/v2/resource_instances',
+            headers={
+                'Accept': 'application/json',
+                'Authorization': 'Bearer ' + auth_token
+            })
+        if response.status_code == 200:
+            resp_json = response.json()
+            for resource in resp_json['resources']:
+                if resource['name'] == self.resource:
+                    return resource['guid']
+            raise RuntimeError('IBM Cloud resource name not found in response')
+        elif last_retry:
+            response.raise_for_status()
+        else:
+            print('IBM Cloud resource retrieval error: ' + str(response.status_code))
+        return None
+
+    def get_get_guid(self, auth_token):
+        retries = 0
+        max_retries = 3
+        while retries < max_retries:
+            retries += 1
+            guid = self.__get_get_guid(retries == max_retries, auth_token)
+            if guid:
+                return guid
+            sleep(1)

--- a/sdcclient/_monitor.py
+++ b/sdcclient/_monitor.py
@@ -13,8 +13,8 @@ except NameError:
 
 class SdMonitorClient(_SdcCommon):
 
-    def __init__(self, token="", sdc_url='https://app.sysdigcloud.com', ssl_verify=True):
-        super(SdMonitorClient, self).__init__(token, sdc_url, ssl_verify)
+    def __init__(self, token="", sdc_url='https://app.sysdigcloud.com', ssl_verify=True, ic_resource=None):
+        super(SdMonitorClient, self).__init__(token, sdc_url, ssl_verify, ic_resource)
         self.product = "SDC"
         self._dashboards_api_version = 'v2'
         self._dashboards_api_endpoint = '/api/{}/dashboards'.format(self._dashboards_api_version)

--- a/sdcclient/_scanning.py
+++ b/sdcclient/_scanning.py
@@ -15,8 +15,8 @@ from sdcclient._common import _SdcCommon
 
 class SdScanningClient(_SdcCommon):
 
-    def __init__(self, token="", sdc_url='https://secure.sysdig.com', ssl_verify=True):
-        super(SdScanningClient, self).__init__(token, sdc_url, ssl_verify)
+    def __init__(self, token="", sdc_url='https://secure.sysdig.com', ssl_verify=True, ic_resource=None):
+        super(SdScanningClient, self).__init__(token, sdc_url, ssl_verify, ic_resource)
         self.product = "SDS"
 
     def add_image(self, image, force=False, dockerfile=None, annotations={}, autosubscribe=True):

--- a/sdcclient/_secure.py
+++ b/sdcclient/_secure.py
@@ -11,8 +11,8 @@ from sdcclient._common import _SdcCommon
 
 class SdSecureClient(_SdcCommon):
 
-    def __init__(self, token="", sdc_url='https://secure.sysdig.com', ssl_verify=True):
-        super(SdSecureClient, self).__init__(token, sdc_url, ssl_verify)
+    def __init__(self, token="", sdc_url='https://secure.sysdig.com', ssl_verify=True, ic_resource=None):
+        super(SdSecureClient, self).__init__(token, sdc_url, ssl_verify, ic_resource)
 
         self.customer_id = None
         self.product = "SDS"


### PR DESCRIPTION
We would prefer users to authenticate themselves with IAM instead of the Sysdig token. 

Example program:
```python
from sdcclient import SdcClient

apikey = # API key
sdc_url = 'https://us-south.monitoring.cloud.ibm.com'
ic_resource = 'my-beloved-instance'
sdclient = SdcClient(apikey, sdc_url=sdc_url, ic_resource=ic_resource)

json_res = sdclient.get_dashboards()
print(json_res)
```